### PR TITLE
Adding error Summary in the response

### DIFF
--- a/configs/mapping.yaml
+++ b/configs/mapping.yaml
@@ -2,42 +2,70 @@ mappings:
 - field: documentation-url
   issue-type: invalid URI
   description: Documentation URL must be a real URL
+  summary-singular: "1 documentation URL must be a real URL"
+  summary-plural: "{count} documentation URLs must be a real URL"
 - field: document-url
   issue-type: invalid URI
   description: Document URL must be a real URL
+  summary-singular: "1 document URL must be a real URL"
+  summary-plural: "{count} document URLs must be a real URL"
 - field: start-date
   issue-type: invalid date
   description: Start date must be a real date
+  summary-singular: "1 start date must be a real date"
+  summary-plural: "{count} start dates must be a real date"
 - field: entry-date
   issue-type: invalid date
   description: Entry date must be a real date
+  summary-singular: "1 entry date must be a real date"
+  summary-plural: "{count} entry dates must be a real date"
 - field: end-date
   issue-type: invalid date
   description: End date must be a real date
+  summary-singular: "1 end date must be a real date"
+  summary-plural: "{count} end dates must be a real date"
 - field: geometry
   issue-type: OSGB out of bounds of England
   description: Geometry must be in England
+  summary-singular: "1 geometry must be in England"
+  summary-plural: "{count} geometries must be in England"
 - field: geometry
   issue-type: Unexpected geom type
   description: Geometry must be a point or polygon
+  summary-singular: "1 geometry must be a point or polygon"
+  summary-plural: "{count} geometries must be a point or polygon"
 - field: geometry
   issue-type: Unexpected geom type within GeometryCollection
   description: Geometry must be a polygon
+  summary-singular: "1 geometry must be a polygon"
+  summary-plural: "{count} geometries must be a polygon"
 - field: geometry
   issue-type: WGS84 out of bounds
   description: Geometry must be in England
+  summary-singular: "1 geometry must be in England"
+  summary-plural: "{count} geometries must be in England"
 - field: geometry
   issue-type: WGS84 out of bounds of England
   description: Geometry must be in England
+  summary-singular: "1 geometry must be in England"
+  summary-plural: "{count} geometries must be in England"
 - field: geometry
   issue-type: invalid WKT
   description: Geometry must be in Well-Known Text (WKT) format
+  summary-singular: "1 geometry must be in Well-Known Text (WKT) format"
+  summary-plural: "{count} geometries must be in Well-Known Text (WKT) format"
 - field: geometry
   issue-type: invalid coordinates
   description: Geometry must use WGS84, OSGB or Mercator coordinates
+  summary-singular: "1 geometry must use WGS84, OSGB or Mercator coordinates"
+  summary-plural: "{count} geometries must use WGS84, OSGB or Mercator coordinates"
 - field: geometry
   issue-type: invalid geometry - not fixable
   description: Geometry must be correctly formatted
+  summary-singular: "1 geometry must be correctly formatted"
+  summary-plural: "{count} geometries must be correctly formatted"
 - field: entry-date
   issue-type: future entry-date
   description: Entry date must be today or in the past
+  summary-singular: "1 entry date must be today or in the past"
+  summary-plural: "{count} entry dates must be today or in the past"

--- a/tests/integration/application/core/test_workflow.py
+++ b/tests/integration/application/core/test_workflow.py
@@ -119,3 +119,4 @@ def test_run_workflow(mocker, mock_directories, mock_fetch_pipeline_csvs, upload
     assert "issue-log" in response_data
     assert "column-field-log" in response_data
     assert "flattened-csv" in response_data
+    assert "error-summary" in response_data

--- a/tests/unit/application/core/test_workflow.py
+++ b/tests/unit/application/core/test_workflow.py
@@ -1,4 +1,4 @@
-from application.core.workflow import updateColumnFieldLog
+from application.core.workflow import updateColumnFieldLog, error_summary
 
 
 def test_updateColumnFieldLog():
@@ -57,3 +57,50 @@ def test_updateColumnFieldLog_no_missing_fields():
         entry["field"] == "reference" and not entry["missing"]
         for entry in column_field_log
     )
+
+
+def test_error_summary():
+    issue_log = [
+        {
+            "dataset": "conservation-area",
+            "resource": "d5b003b74563bb5bcf06742ee27f9dd573a47a123f8f5d975d9e04187fa58eff",
+            "line-number": "2",
+            "entry-number": "1",
+            "field": "geometry",
+            "issue-type": "OSGB out of bounds of England",
+            "value": "",
+            "severity": "error",
+            "description": "Geometry must be in England",
+        },
+        {
+            "dataset": "conservation-area",
+            "resource": "d5b003b74563bb5bcf06742ee27f9dd573a47a123f8f5d975d9e04187fa58eff",
+            "line-number": "3",
+            "entry-number": "2",
+            "field": "geometry",
+            "issue-type": "OSGB out of bounds of England",
+            "value": "",
+            "severity": "error",
+            "description": "Geometry must be in England",
+        },
+        {
+            "dataset": "conservation-area",
+            "resource": "d5b003b74563bb5bcf06742ee27f9dd573a47a123f8f5d975d9e04187fa58eff",
+            "line-number": "3",
+            "entry-number": "2",
+            "field": "start-date",
+            "issue-type": "invalid date",
+            "value": "40/04/2024",
+            "severity": "error",
+            "description": "Start date must be a real date",
+        },
+    ]
+    column_field_log = [{"field": "reference", "missing": True}]
+    json_data = error_summary(issue_log, column_field_log)
+    expected_messages = [
+        "2 geometries must be in England",
+        "1 start date must be a real date",
+        "Reference column missing",
+    ]
+
+    assert any(message in json_data for message in expected_messages)


### PR DESCRIPTION
Reference ticket: https://trello.com/c/5Lx4U7uL/1189-improve-error-summary-messages

This is to generate the error Summary from backend and return in the response to frontend taking issue log and column field log as input.