### PR TITLE
Adds A4D, CA document, TPO dataset

### DIFF
--- a/configs/mandatory_fields.yaml
+++ b/configs/mandatory_fields.yaml
@@ -1,5 +1,9 @@
 article-4-direction:
 - reference
+- name
+- description
+- document-url
+- documentation-url
 article-4-direction-area:
 - reference
 - geometry
@@ -9,6 +13,18 @@ conservation-area:
 - reference
 - geometry
 - name
+conservation-area-document:
+- reference
+- name
+- conservation-area
+- document-url
+- documentation-url
+- document-type
+tree-preservation-order:
+- reference
+- name
+- document-url
+- documentation-url
 tree-preservation-zone:
 - reference
 - geometry

--- a/configs/mapping.yaml
+++ b/configs/mapping.yaml
@@ -31,14 +31,24 @@ mappings:
   summary-plural: "{count} start dates must be a real date"
 - field: made-date
   issue-type: missing value
-  description: made date missing
+  description: Made date missing
   summary-singular: "1 made date missing"
   summary-plural: "{count} made dates missing"
 - field: made-date
   issue-type: invalid date
-  description: made date must be a real date
+  description: Made date must be a real date
   summary-singular: "1 made date must be a real date"
   summary-plural: "{count} made dates must be a real date"
+- field: confirmed-date
+  issue-type: missing value
+  description: Confirmed date missing
+  summary-singular: "1 confirmed date missing"
+  summary-plural: "{count} confirmed dates missing"
+- field: confirmed-date
+  issue-type: invalid date
+  description: Confirmed date must be a real date
+  summary-singular: "1 confirmed date must be a real date"
+  summary-plural: "{count} confirmed dates must be a real date"
 - field: entry-date
   issue-type: missing value
   description: Entry date missing

--- a/configs/mapping.yaml
+++ b/configs/mapping.yaml
@@ -29,6 +29,16 @@ mappings:
   description: Start date must be a real date
   summary-singular: "1 start date must be a real date"
   summary-plural: "{count} start dates must be a real date"
+- field: made-date
+  issue-type: missing value
+  description: made date missing
+  summary-singular: "1 made date missing"
+  summary-plural: "{count} made dates missing"
+- field: made-date
+  issue-type: invalid date
+  description: made date must be a real date
+  summary-singular: "1 made date must be a real date"
+  summary-plural: "{count} made dates must be a real date"
 - field: entry-date
   issue-type: missing value
   description: Entry date missing


### PR DESCRIPTION
Adds mandatory fields for article-4-direction, conservation area document and tree preservation order.
Adds mappings for confirmed-date and made-date columns (TPO)